### PR TITLE
[#9] Fix Export of Only Selected Object

### DIFF
--- a/convex_decomposition.py
+++ b/convex_decomposition.py
@@ -417,6 +417,7 @@ class ConvexDecompositionRunOperator(ConvexDecompositionBaseOperator):
             bpy.ops.wm.obj_export(
                 filepath=str(fname),
                 check_existing=False,
+                export_selected_objects=True,
             )
         return fname
 


### PR DESCRIPTION
This ensures that _only_ the selected object gets targeted by the convex decomposition.

Closes #9.